### PR TITLE
no more loops

### DIFF
--- a/src/pages/about.ts
+++ b/src/pages/about.ts
@@ -1,4 +1,4 @@
-import { type Compilation, type Page, type GetFrontmatter } from "@greenwood/cli";
+import type { Compilation, Page, GetFrontmatter } from "@greenwood/cli";
 
 const html: string = `
   <h2>About Page</h2>


### PR DESCRIPTION
Avoiding nested `type` seems to make the issue go away?

```js
// ❌ 
import { type foo } from 'bar';

// ✅ 
import type { foo } from 'bar';
```

```sh
➜  greenwood-loops git:(resolve-loops) npm run dev

> greenwood-loops@1.0.0 dev
> NODE_OPTIONS='--import @greenwood/cli/register --experimental-strip-types' greenwood develop

(node:85254) ExperimentalWarning: Type Stripping is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:85254) ExperimentalWarning: Type Stripping is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
-------------------------------------------------------
Welcome to Greenwood (v0.32.0) ♻️
-------------------------------------------------------
Initializing project config
Initializing project workspace contexts
Generating graph of workspace files...
building from local sources...
(node:85254) ExperimentalWarning: Type Stripping is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
(node:85254) ExperimentalWarning: Type Stripping is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Running Greenwood with the develop command.
Started local development server at http://localhost:1984
Now watching workspace directory (./src) for changes...
```